### PR TITLE
Gemfile : Remove `therubyracer`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,5 @@
 # > bundle exec jekyll serve
 
 source 'https://rubygems.org'
-gem 'therubyracer'
 gem 'github-pages'
 gem 'jekyll-paginate'


### PR DESCRIPTION
This was breaking the Docker-based server setup documented in README.md. I don't know what it was there for, but assume it was because it was in the original instructions at https://help.github.com/articles/setting-up-your-github-pages-site-locally-with-jekyll/. The latest version of that page no longer includes that gem, and I've verified that the website still generates locally both with and without Docker.