### PR TITLE
Documentation link

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -63,7 +63,7 @@
                     <a class="menu" href="{{ site.baseurl }}/demos/">Demos</a>
                 </li>
                  <li {% if page.url contains '/documentation' %} class="active" {% endif %}>
-                    <a class="menu" href="{{ site.baseurl }}/documentation/">Documentation</a>
+                    <a class="menu" href="{{ site.baseurl }}/documentation/{{ site.latestGafferVersion }}">Documentation</a>
                 </li>
             </ul>
         </div>


### PR DESCRIPTION
Point to specific version of documentation. This has two benefits :

- People can bookmark links that aren't going to be broken when documentation gets restructured.
- We won't have to manage these awkward ["copy latest docs to root" commits](https://github.com/GafferHQ/documentation/commit/afc2dff47939b60bb11687422c2ce8f03413b6f0) any more, which will make it slightly easier to automate the documentation upload as part of the Gaffer release process.

Any concerns with this @medubelko?

