### PR TITLE
Fix HTML errors

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,3 +6,4 @@ gems:
    - jekyll-paginate
 
 latestGafferVersion: 0.50.0.0
+copyrightYear: 2018

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -22,8 +22,8 @@
                 <div class="row">
                     <div class="col-xs-12">
                         <p class="text-uppercase lead white"><a href="{{ site.baseurl }}" class="white">Gaffer</a></p>
-                        <p class="white">© <script>document.write(new Date().getFullYear())</script><noscript>2018</noscript> Image Engine Design Inc. All rights reserved.<br></p>
-                        <p class="white">© <script>document.write(new Date().getFullYear())</script><noscript>2018</noscript> John Haddon. All rights reserved.</p>
+                        <p class="white">© {{ site.copyrightYear }} Image Engine Design Inc. All rights reserved.<br></p>
+                        <p class="white">© {{ site.copyrightYear }} John Haddon. All rights reserved.</p>
                     </div>
                 </div>
             </section>

--- a/_posts/2015-07-8-jurassicWorldInterview.md
+++ b/_posts/2015-07-8-jurassicWorldInterview.md
@@ -2,7 +2,7 @@
 layout: post
 title: "Gaffer at the movies"
 subtitle: "Jurassic World"
-icon: "http://s3.cgsociety.org/articles/2015/07/07/l_pJzPy00i0LBRcsmLgYvg.jpg"
+icon: "https://cg1.cgsociety.org/uploads/news_images/original/69dd85bf1528441294.4291124.jpg"
 ---
 
 [CGSociety](http://www.cgsociety.org) has a great interview with Martyn Culpitt, VFX supervisor at Image Engine, talking about Image Engine's work on Jurassic World.

--- a/_posts/2015-10-21-appleseedInterview.md
+++ b/_posts/2015-10-21-appleseedInterview.md
@@ -10,4 +10,4 @@ In the interview François talks briefly about the recent integration of Applese
 
  > That is the work of a developer of Appleseed called Esteban Tovagliari. He did a terrific job over the last year...With Gaffer and Appleseed together we have a really nice open source lookdev application. That is something that did not exist before.
 
-Head on over to BlenderDiplom to read the [full interview](http://blenderdiplom.com/en/interviews/607-interview-francois-beaune-on-appleseed-renderer.html), or take a peek at our [demos section]({{ site.baseurl }}/demos.html) where you'll find some short videos of the integration in action.
+Head on over to BlenderDiplom to read the [full interview](http://blenderdiplom.com/en/interviews/607-interview-francois-beaune-on-appleseed-renderer.html), or take a peek at the [Appleseed demo]({{ site.baseurl }}/news/interactive-appleseed/) where you'll find some short videos of the integration in action.

--- a/community.html
+++ b/community.html
@@ -18,7 +18,7 @@ title: Gaffer | Community
                         + '&parenturl=' + encodeURIComponent(window.location.href);
                 </script>
             </div>
-        <div>
+        </div>
     </div>
 </section>
  

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@ title: Gaffer | Home
     <div class="row ptb-15 wow">
         <div class="col-xs-12 col-md-6 pull-right">
             <!-- Shader graph -->
-            <a class="cbox-gallary1" href="img/headers/header_graph.jpg">
+            <a class="cbox-gallary1" href="/img/headers/header_graph.jpg">
                 <div class="bg-img" style="height: 300px; background-image: url(img/headers/header_graph.jpg); background-position: right"></div>
             </a>
         </div>
@@ -60,7 +60,7 @@ title: Gaffer | Home
     <div class="row ptb-15 wow">
         <div class="col-xs-12 col-md-6">
             <!-- Gaffy IPR -->
-            <a class="cbox-gallary1" href="img/headers/carousel_bot.jpg">
+            <a class="cbox-gallary1" href="/img/headers/carousel_bot.jpg">
                 <div class="bg-img text-center" style="height: 300px; background-image: url(img/headers/carousel_bot.jpg); background-position: left"></div>
             </a>
         </div>
@@ -92,7 +92,7 @@ title: Gaffer | Home
 <section id="service" class="container ptb ptb-sm-80 wow">
     <div class="row text-center">
         <h2>Features</h2>
-    </row>
+    </div>
     <div class="row">
         <div class="col-md-4 mb-30 mt-60">
             <div class="page-icon-top pb-0"><i class="fa fa-smile-o"></i></div>

--- a/news.html
+++ b/news.html
@@ -26,15 +26,19 @@ title: Gaffer | News
 
                     {% assign iconPrefix = post.icon | slice: 0, 4 %}
 
-                    {% if iconPrefix == "http" %}
-                    
-                        <img src="{{ post.icon }}" alt="" />
-                    
-                    {% else %}
-                    
-                        <img src="{{ site.baseurl }}{{ post.icon }}" alt="" />
-                    
-                    {% endif %}
+                    {% unless iconPrefix == "" %}
+
+                        {% if iconPrefix == "http" %}
+                        
+                            <img src="{{ post.icon }}" alt="" />
+
+                        {% else %}
+                        
+                            <img src="{{ site.baseurl }}{{ post.icon }}" alt="" />
+
+                        {% endif %}
+                        
+                    {% endunless %}
 
                 </div>
                 <div class="mb-30">


### PR DESCRIPTION
@johnhaddon I grabbed your PR on a local VM, and fixed all the errors the proofer threw at me. This PR fixes the legitimate HTML issues with the site, and some of the illegitimate ones.

Most of the errors should be gone, but I couldn't reproduce the numerous `internally linking to <URI>, which doesn't exist` errors that Travis reported, caused by nav links like `{{ site.baseurl }}/downloads/` in `header.html`. They are in fact perfectly valid HTML. I suspect there's a conflict between Jekyll's directory structure/variable and Nokogiri. A few other public projects have mentioned running into this issue, but I didn't find any solutions. I believe some projects just live with the errors.

I suppose the best course of action now is to merge this and see what errors remain with your Travis PR.

---

**Note:** IE's version of Jekyll appears to precede the time when `{% page_url <post_title> %}` (syntax to dynamically produce internal links to blog posts) was available. For now, I've had to add an absolute link to one of the posts, which could break at some later point. It would be prudent to update Jekyll/Ruby on our end, if we want to avoid further link-related surprises...