### PR TITLE
Config : Prevent future posts from publishing immediately

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,7 @@
 paginate: 1
 permalink: /news/:title/
 baseurl:
+future: false
 google_analytics: UA-125947352-1
 gems:
    - jekyll-paginate


### PR DESCRIPTION
Didn't notice the GitHub-pages version of Jekyll had future posts enabled by default. Should be fixed with this.