### PR TITLE
Configure Travis CI for site validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 _site
 Gemfile.lock
+.bundle
+.ruby-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: ruby
+rvm:
+  - 2.3.7
+script:
+  - bundle exec jekyll build
+  - bundle exec htmlproofer ./_site --only-4xx --check-html --empty-alt-ignore --url-ignore "/vimeo.com/"
+env:
+  global:
+    - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer

--- a/Gemfile
+++ b/Gemfile
@@ -19,3 +19,4 @@
 source 'https://rubygems.org'
 gem 'github-pages'
 gem 'jekyll-paginate'
+gem 'html-proofer'


### PR DESCRIPTION
This is a copy of John's Travis config (#22) so we can re-test the validator with the fixes from https://github.com/gafferhq/gafferhq.github.io/pull/23.