### PR TITLE
Update Gaffer version

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,5 +6,5 @@ google_analytics: UA-125947352-1
 gems:
    - jekyll-paginate
 
-latestGafferVersion: 0.50.0.0
+latestGafferVersion: 0.52.3.3
 copyrightYear: 2018


### PR DESCRIPTION
This is a prep PR. There's no way to have dynamic redirects with Jekyll, so this will need to be merged after [documentation](https://www.github.com/gafferhq/documentation) is updated to 52.3.3 (or later).