### PR TITLE
Fix Docker builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ rvm:
   - 2.3.7
 script:
   - bundle exec jekyll build
-  - bundle exec htmlproofer ./_site --only-4xx --check-html --empty-alt-ignore --url-ignore "/vimeo.com/"
+  - gem install html-proofer
+  - htmlproofer ./_site --only-4xx --check-html --empty-alt-ignore --url-ignore "/vimeo.com/"
 env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer

--- a/Gemfile
+++ b/Gemfile
@@ -19,4 +19,3 @@
 source 'https://rubygems.org'
 gem 'github-pages'
 gem 'jekyll-paginate'
-gem 'html-proofer'


### PR DESCRIPTION
GitHubPages only supports a white-listed subset of Gems. This causes builds
in environments that mirror what is available on GitHubPages to fail.

html-proofer is used on travis for validation of links, so this moves it t
a travis-only place.