### PR TITLE
Link fixes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,4 +10,4 @@ latestGafferVersion: 0.53.4.0
 copyrightYear: 2019
 images: "/resources/images"
 demos: "/resources/demos"
-docs: "/documentation"
+docs: "https://www.gafferhq.org/documentation"

--- a/_posts/2016-08-03-siggraphAndDigiPro.md
+++ b/_posts/2016-08-03-siggraphAndDigiPro.md
@@ -2,14 +2,12 @@
 layout: post
 title: "Siggraph and DigiPro"
 subtitle: "Gaffer gets published"
-icon: "https://www.fxguide.com/wp-content/uploads/2016/07/digipto-18-660x440.jpg"
 ---
 
 The buzz surrounding Gaffer was pretty solid at Siggraph this year, thanks in part to our [Gaffer paper](http://dl.acm.org/authorize?N19757), published and presented at [DigiPro](http://dp2016.digiproconf.org/). If you're unfamiliar with DigiPro, its a co-located symposium that takes place the day before Siggraph. The presentations focus on production proven technology, providing a space for long-form papers about actual production challenges (rather than pure research). Image Engine has presented at DigiPro in the past, about our Cortex based rendering pipeline, but this was the first paper about Gaffer itself.
 
 As usual, DigiPro sold out fast, and we presented to a packed house.
 
-![DigiPro Audience]({{ page.icon }})
 <br>*Source: FXGuide.com*
 
 There's a full breakdown of the event on [FXGuide](https://www.fxguide.com/quicktakes/siggraph-saturday-digipro/). The overall audience reaction to Gaffer was very positive. Quite a few people found us during the lunch break to congratulate and express an interest in Gaffer, both as a framework and as a lighting application.

--- a/_posts/2019-02-14-announce-gaffer-53.md
+++ b/_posts/2019-02-14-announce-gaffer-53.md
@@ -82,7 +82,7 @@ Many nodes have had breaking changes or have been replaced. You can open existin
     - For baking Arnold shaders on meshes into textures.
     - [Demo]({{ site.demos }}/gaffer-53-arnoldtexturebake-node-public.gfr)
 - <span class="changelog changelog-updated">Updated</span> ![Box node]({{ images }}/gaffer-53-box-node.png)
-    - [Boxes can now be disabled]({{ site.docs }}/{{ site.latestGafferVersion }}/WorkingWithTheNodeGraph/Box/index.html#setting-up-a-box-for-pass-through) (<kbd>D</kbd>) when their new `passThrough` plug is connected.
+    - [Boxes can now be disabled]({{ site.docs }}/0.53.4.0/WorkingWithTheNodeGraph/Box/index.html#setting-up-a-box-for-pass-through) (<kbd>D</kbd>) when their new `passThrough` plug is connected.
 
 <!-- Breaking Changes -->
 


### PR DESCRIPTION
There were a number of broken links that were causing CI tests to fail (and have been for a while). We need to treat CI failures are blocking.