### PR TITLE
Update jQuery version

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -29,7 +29,10 @@
             </section>
         </footer>
 
-	<script src="http://code.jquery.com/jquery-latest.js"></script>
+	<script
+		src="https://code.jquery.com/jquery-2.2.4.min.js"
+		integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44="
+		crossorigin="anonymous"></script>
 	<script src="{{ site.baseurl }}/js/plugin/jquery.easing.js" type="text/javascript"></script>
 	<script src="{{ site.baseurl }}/js/jquery-ui.min.js" type="text/javascript"></script>
 	<script src="{{ site.baseurl }}/js/bootstrap.min.js" type="text/javascript"></script>


### PR DESCRIPTION
The site's JS (in particular, the carousel and nav) are broken. I'm not sure when exactly this happened. Both FF and Chrome are blocking the URL to jQuery's site, because it's an old unsecured HTTP link. This will hopefully fix that.

The new link is also to jQuery 2, which should speed up load times a little.