### PR TITLE
GitHub Workflows : Update host OS to Ubuntu 20.04

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,7 +6,7 @@ jobs:
 
   Check:
 
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
 
     steps:
 

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -10,7 +10,7 @@ jobs:
 
   Update:
 
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
 
     steps:
 


### PR DESCRIPTION
As described at actions/virtual-environments#3287 support for Ubuntu 16.04 was dropped by GitHub on September 20th. Our CI workflows are now failing to start because they can't find a worker.

Our choices are 18.04 or 20.04. In the absence of any other reason, I've chosen 20.04 because it will last longer before we have to update again.