### PR TITLE
Redirect `www.gafferhq.org/blog` to `blog.gafferhq.org`

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -6,10 +6,10 @@ title: Gaffer | Redirect
 <html lang="en-US">
     <meta charset="utf-8">
     <title>Redirecting&hellip;</title>
-    <link rel="canonical" href="{{ site.baseurl }}/news/">
-    <script>location="{{ site.baseurl }}/news/"</script>
-    <meta http-equiv="refresh" content="0; url={{ site.baseurl }}/news/">
+    <link rel="canonical" href="https://blog.gafferhq.org">
+    <script>location="https://blog.gafferhq.org"</script>
+    <meta http-equiv="refresh" content="0; url=https://blog.gafferhq.org">
     <meta name="robots" content="noindex">
     <h1>Redirecting&hellip;</h1>
-    <a href="{{ site.baseurl }}/news/">Click here if you are not redirected.</a>
+    <a href="https://blog.gafferhq.org">Click here if you are not redirected.</a>
 </html>


### PR DESCRIPTION
Not to the ancient news section.