### PR TITLE
Add link to GafferHQ Twitter account

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -14,6 +14,9 @@
                             <li class="link mr-0" style="padding: 0 10px">
                                 <a class="white" href="https://vimeo.com/cortex" style="font-size: 36px"><i class="fa fa-vimeo-square"></i></a>
                             </li>
+							<li class="link mr-0" style="padding: 0 10px">
+                                <a class="white" href="https://twitter.com/GafferHQ" style="font-size: 36px"><i class="fa fa-twitter-square"></i></a>
+                            </li>
                         </ul>
                     </div>
                 </div>


### PR DESCRIPTION
This updates the footer to include a link to the Twitter account.