### PR TITLE
CI : Limit html-proofer install to versions < 5.0.0

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -27,7 +27,7 @@ jobs:
       run: |
         bundle config path vendor/bundle
         bundle install
-        gem install html-proofer
+        gem install html-proofer -v "<5.0.0"
       env:
         NOKOGIRI_USE_SYSTEM_LIBRARIES: true # speeds up installation of html-proofer
 


### PR DESCRIPTION
This is an attempt at fixing the current CI failures when installing `html-proofer`. According to [this](https://rubygems.org/gems/html-proofer/versions/5.0.0) `html-proofer` 5.0.0 dropped support for Ruby 2.6 so won't work in the current CI environment, so this change should limit the gem install to previous compatible versions.