### PR TITLE
Update Gaffer to 1.2.0.1 and add Windows download

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,6 +7,6 @@ gems:
 - jekyll-paginate
 google_analytics: UA-125947352-1
 images: /resources/images
-latestGafferVersion: 1.1.9.0
+latestGafferVersion: 1.2.0.1
 paginate: 1
 permalink: /news/:title/

--- a/download.html
+++ b/download.html
@@ -11,8 +11,8 @@ title: Gaffer | Download
 <section id="download" class="container">
     <div class="row ptb-15 ptb-xs-30 pt-80">
         <div class="col-sm-5 pb-xs-60 text-center">
-            <a class="btn btn-block btn-lg btn-color-a" style="font-size: 16px" href="https://github.com/GafferHQ/gaffer/releases/download/{{ site.latestGafferVersion }}/gaffer-{{ site.latestGafferVersion }}-linux-python2.tar.gz"><i class="fa fa-download"></i>Gaffer for Linux (Python 2)</a>
-            <a class="btn btn-block btn-lg btn-color-a" style="font-size: 16px" href="https://github.com/GafferHQ/gaffer/releases/download/{{ site.latestGafferVersion }}/gaffer-{{ site.latestGafferVersion }}-linux-python3.tar.gz"><i class="fa fa-download"></i>Gaffer for Linux (Python 3)</a>
+            <a class="btn btn-block btn-lg btn-color-a" style="font-size: 16px" href="https://github.com/GafferHQ/gaffer/releases/download/{{ site.latestGafferVersion }}/gaffer-{{ site.latestGafferVersion }}-linux.tar.gz"><i class="fa fa-download"></i>Gaffer for Linux</a>
+            <a class="btn btn-block btn-lg btn-color-a" style="font-size: 16px" href="https://github.com/GafferHQ/gaffer/releases/download/{{ site.latestGafferVersion }}/gaffer-{{ site.latestGafferVersion }}-windows.zip"><i class="fa fa-download"></i>Gaffer for Windows</a>
         </div>
         <div class="col-sm-7">
             <ul style="padding-left: 1em; list-style-type:'➜'">
@@ -32,6 +32,7 @@ title: Gaffer | Download
             <h3>Operating System</h3>
             <ul>
                 <li>Linux (most tested on CentOS 7 and Ubuntu 18)</li>
+                <li>Windows 10/11 (64 bit)</li>
             </ul>
             <h3>Hardware</h3>
             <ul>
@@ -42,8 +43,8 @@ title: Gaffer | Download
             <h2>3rd-Party Tools</h2>
             <p>Gaffer is compatible with the following tools:</p>
             <ul>
-                <li>Arnold 6</li>
-                <li>3Delight 13</li>
+                <li>Arnold 7.1</li>
+                <li>3Delight 2</li>
                 <li>Tractor 2</li>
             </ul>
         </div>


### PR DESCRIPTION
Update to Gaffer 1.2.0.1 and add the Windows release to the download page.

- Replace Linux Python 2 & 3 download links with Linux and Windows links.
- Add Windows 10/11 to required operating systems.
- Update Arnold and 3Delight versions described in the 3rd-party tools section.