### PR TITLE
CI : Update to Ruby 2.7

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,7 +14,7 @@ jobs:
 
     - uses: actions/setup-ruby@v1
       with:
-        ruby-version: 2.6
+        ruby-version: 2.7
 
     - uses: actions/cache@v2
       with:


### PR DESCRIPTION
The nokogiri version installed by html-proofer no longer supports Ruby 2.6.  `actions/setup-ruby@v1` supports Ruby 2.7, so updating would be preferable to attempting to lock to an old nokogiri version.

Putting this up to see what happens on CI... :crossed_fingers: 