### PR TITLE
Update workflow : Avoid `distutils`

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Update
       id: update
       run: |
-        ./update.py --set-outputs 1
+        ./update.py --set-outputs
 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v3

--- a/update.py
+++ b/update.py
@@ -5,7 +5,6 @@ import yaml
 
 import argparse
 import datetime
-import distutils.util
 import os
 import sys
 import urllib.request
@@ -21,8 +20,8 @@ parser.add_argument(
 parser.add_argument(
 	"--set-outputs",
 	dest = "setOutputs",
-	type = distutils.util.strtobool,
-	default = "0",
+	default = False,
+	action = "store_true",
 	help = "Echo the outputs needed by `.github/workflows/update.yml`."
 )
 args = parser.parse_args()


### PR DESCRIPTION
Same fix as https://github.com/GafferHQ/documentation/pull/92 after `distutils` removal from Python 3.12.