### PR TITLE
Gaffer 1.4 updates

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,7 +12,7 @@ jobs:
 
     - uses: actions/checkout@v2
 
-    - uses: actions/setup-ruby@v1
+    - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -27,7 +27,8 @@ jobs:
       run: |
         bundle config path vendor/bundle
         bundle install
-        gem install html-proofer -v "<5.0.0"
+        gem install nokogiri -v "~>1.15.6"
+        gem install html-proofer -v "<5.0.0" --minimal-deps
       env:
         NOKOGIRI_USE_SYSTEM_LIBRARIES: true # speeds up installation of html-proofer
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,4 +37,4 @@ jobs:
 
     - name: Check
       run: |
-        htmlproofer ./_site --only-4xx --ignore-urls "/vimeo.com/"
+        htmlproofer ./_site --only-4xx --ignore-urls "/vimeo.com/,/twitter.com/,/arnoldrenderer.com/,/shotgridsoftware.com/"

--- a/_config.yml
+++ b/_config.yml
@@ -7,6 +7,6 @@ gems:
 - jekyll-paginate
 google_analytics: UA-125947352-1
 images: /resources/images
-latestGafferVersion: 1.3.15.0
+latestGafferVersion: 1.4.0.0
 paginate: 1
 permalink: /news/:title/

--- a/download.html
+++ b/download.html
@@ -54,6 +54,7 @@ title: Gaffer | Download
                 <ul>
                     <li>A minimum of 7.3.1.0 is required when using Arnold 7.3</li>
                 </ul>
+                <li>Cycles 4.0.2</li>
                 <li>3Delight 2</li>
                 <li>Tractor 2</li>
                 <li>Deadline support can be enabled by installing the <a href="https://github.com/hypothetical-inc/GafferDeadline">GafferDeadline</a> extension</li>

--- a/download.html
+++ b/download.html
@@ -56,6 +56,7 @@ title: Gaffer | Download
                 </ul>
                 <li>3Delight 2</li>
                 <li>Tractor 2</li>
+                <li>Deadline support can be enabled by installing the <a href="https://github.com/hypothetical-inc/GafferDeadline">GafferDeadline</a> extension</li>
             </ul>
         </div>
     </div>

--- a/download.html
+++ b/download.html
@@ -11,7 +11,8 @@ title: Gaffer | Download
 <section id="download" class="container">
     <div class="row ptb-15 ptb-xs-30 pt-80">
         <div class="col-sm-5 pb-xs-60 text-center">
-            <a class="btn btn-block btn-lg btn-color-a" style="font-size: 16px" href="https://github.com/GafferHQ/gaffer/releases/download/{{ site.latestGafferVersion }}/gaffer-{{ site.latestGafferVersion }}-linux.tar.gz"><i class="fa fa-download"></i>Gaffer for Linux</a>
+            <a class="btn btn-block btn-lg btn-color-a" style="font-size: 16px" href="https://github.com/GafferHQ/gaffer/releases/download/{{ site.latestGafferVersion }}/gaffer-{{ site.latestGafferVersion }}-linux-gcc9.tar.gz"><i class="fa fa-download"></i>Gaffer for Linux (GCC 9)</a>
+            <a class="btn btn-block btn-lg btn-color-a" style="font-size: 16px" href="https://github.com/GafferHQ/gaffer/releases/download/{{ site.latestGafferVersion }}/gaffer-{{ site.latestGafferVersion }}-linux-gcc11.tar.gz"><i class="fa fa-download"></i>Gaffer for Linux (GCC 11)</a>
             <a class="btn btn-block btn-lg btn-color-a" style="font-size: 16px" href="https://github.com/GafferHQ/gaffer/releases/download/{{ site.latestGafferVersion }}/gaffer-{{ site.latestGafferVersion }}-windows.zip"><i class="fa fa-download"></i>Gaffer for Windows</a>
         </div>
         <div class="col-sm-7">
@@ -31,7 +32,10 @@ title: Gaffer | Download
             <p>Gaffer has the following requirements:</p>
             <h3>Operating System</h3>
             <ul>
-                <li>Linux (most tested on CentOS 7 and Ubuntu 18)</li>
+                <li>Linux (most tested on CentOS 7 and AlmaLinux 9)</li>
+                <ul>
+                    <li>GCC 11 builds require distributions with glibc 2.28 or higher, and are not compatible with CentOS 7</li>
+                </ul>
                 <li>Windows 10/11 (64 bit)</li>
             </ul>
             <h3>Hardware</h3>
@@ -43,7 +47,10 @@ title: Gaffer | Download
             <h2>3rd-Party Tools</h2>
             <p>Gaffer is compatible with the following tools:</p>
             <ul>
-                <li>Arnold 7.1</li>
+                <li>Arnold 7.2 & 7.3</li>
+                <ul>
+                    <li>A minimum of 7.3.1.0 is required when using Arnold 7.3</li>
+                </ul>
                 <li>3Delight 2</li>
                 <li>Tractor 2</li>
             </ul>

--- a/download.html
+++ b/download.html
@@ -37,6 +37,9 @@ title: Gaffer | Download
                     <li>GCC 11 builds require distributions with glibc 2.28 or higher, and are not compatible with CentOS 7</li>
                 </ul>
                 <li>Windows 10/11 (64 bit)</li>
+                <ul>
+                    <li>Installing the <a href="https://learn.microsoft.com/en-US/cpp/windows/latest-supported-vc-redist?view=msvc-170#latest-microsoft-visual-c-redistributable-version">Microsoft Visual C++ Redistributable</a> is required on Windows</li>
+                </ul>
             </ul>
             <h3>Hardware</h3>
             <ul>

--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@ title: Gaffer | Home
         </div>
         <div class="col-xs-12 col-md-6">
             <h3 class="mt-60 text-center">Build Shaders</h3>
-            <p>With full support for <a href="https://www.arnoldrenderer.com" alt="Arnold homepage">Arnold</a> and <a href="https://www.3delight.com" alt="3Delight homepage">3Delight's</a> powerful industry-standard shaders, use the robust node plug-outs to quickly build compelling looks. For extra customization, arrange and write custom shaders using <a href="https://opensource.imageworks.com/osl.html" alt="Open Shading Language homepage">Open Shading Language</a> nodes and code.</p>
+            <p>With full support for <a href="https://www.arnoldrenderer.com" alt="Arnold homepage">Arnold</a>, <a href="https://www.cycles-renderer.org" alt="Cycles homepage">Cycles</a>, and <a href="https://www.3delight.com" alt="3Delight homepage">3Delight's</a> powerful industry-standard shaders, use the robust node plug-outs to quickly build compelling looks. For extra customization, arrange and write custom shaders using <a href="https://opensource.imageworks.com/osl.html" alt="Open Shading Language homepage">Open Shading Language</a> nodes and code.</p>
         </div>
     </div>
     <div class="row ptb-15 wow">
@@ -107,7 +107,7 @@ title: Gaffer | Home
         <div class="col-md-4 mb-30 mt-60">
             <div class="page-icon-top pb-0"><i class="fa fa-cogs"></i></div>
             <h4>Flexible</h4>
-            <p>A renderer abstraction layer enables common workflows between several renderers. Supports <a href="https://www.arnoldrenderer.com" alt="Arnold homepage">Arnold</a>, <a href="https://appleseedhq.net" alt="Appleseed homepage">Appleseed</a>, <a href="https://www.3delight.com" alt="3Delight homepage">3Delight</a>, and <a href="https://renderman.pixar.com/products/tools/tractor.html" alt="Tractor homepage">Tractor</a>.</p>
+            <p>A renderer abstraction layer enables common workflows between several renderers. Supports <a href="https://www.arnoldrenderer.com" alt="Arnold homepage">Arnold</a>, <a href="https://www.cycles-renderer.org" alt="Cycles homepage">Cycles</a>, <a href="https://www.3delight.com" alt="3Delight homepage">3Delight</a>, and <a href="https://renderman.pixar.com/products/tools/tractor.html" alt="Tractor homepage">Tractor</a>.</p>
         </div>
     </div>
     <div class="row pt-15">

--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@ title: Gaffer | Home
         </div>
         <div class="col-xs-12 col-md-6">
             <h3 class="mt-60 text-center">Build Shaders</h3>
-            <p>With full support for <a href="https://www.arnoldrenderer.com" alt="Arnold homepage">Arnold</a>, <a href="https://www.cycles-renderer.org" alt="Cycles homepage">Cycles</a>, and <a href="https://www.3delight.com" alt="3Delight homepage">3Delight's</a> powerful industry-standard shaders, use the robust node plug-outs to quickly build compelling looks. For extra customization, arrange and write custom shaders using <a href="https://opensource.imageworks.com/osl.html" alt="Open Shading Language homepage">Open Shading Language</a> nodes and code.</p>
+            <p>With full support for <a href="https://www.arnoldrenderer.com" alt="Arnold homepage">Arnold</a>, <a href="https://www.cycles-renderer.org" alt="Cycles homepage">Cycles</a>, and <a href="https://www.3delight.com" alt="3Delight homepage">3Delight's</a> powerful industry-standard shaders, use the robust node plug-outs to quickly build compelling looks. For extra customization, arrange and write custom shaders using <a href="https://openshadinglanguage.org" alt="Open Shading Language homepage">Open Shading Language</a> nodes and code.</p>
         </div>
     </div>
     <div class="row ptb-15 wow">
@@ -119,7 +119,7 @@ title: Gaffer | Home
         <div class="col-md-4 mb-30 mt-60">
             <div class="page-icon-top pb-0"><i class="fa fa-users"></i></div>
             <h4>Open Source</h4>
-            <p>Built on a wealth of tested open-source VFX libraries, including <a href="https://www.openexr.com" alt="OpenEXR homepage">OpenEXR</a>, <a href="https://sites.google.com/site/openimageio/home" alt="OpenImageIO homepage">OpenImageIO</a>, <a href="https://opencolorio.org" alt="OpenColorIO homepage">OpenColorIO</a>, <a href="https://opensource.imageworks.com/osl.html" alt="Open Shading Language homepage">Open Shading Language</a>, and <a href="https://github.com/ImageEngine/cortex" alt="Cortex GitHub project">Cortex</a>.</p>
+            <p>Built on a wealth of tested open-source VFX libraries, including <a href="https://www.openexr.com" alt="OpenEXR homepage">OpenEXR</a>, <a href="https://sites.google.com/site/openimageio/home" alt="OpenImageIO homepage">OpenImageIO</a>, <a href="https://opencolorio.org" alt="OpenColorIO homepage">OpenColorIO</a>, <a href="https://openshadinglanguage.org" alt="Open Shading Language homepage">Open Shading Language</a>, and <a href="https://github.com/ImageEngine/cortex" alt="Cortex GitHub project">Cortex</a>.</p>
         </div>
         <div class="col-md-4 mb-30 mt-60">
             <div class="page-icon-top pb-0"><i class="fa fa-road"></i></div>

--- a/resources.html
+++ b/resources.html
@@ -60,7 +60,7 @@ title: Gaffer | Resources
             <div class="col-md-10 col-md-offset-1">
                 <h2 class="text-center landing">Extensions</h2>
                 <h3><i class="fas fa-cog"></i> Deadline Dispatcher</h3>
-                <p class="lead"><a href="https://github.com/ericmehl/GafferDeadline">GafferDeadline</a> is a <a href="https://awsthinkbox.com/deadline">Deadline</a> dispatcher created by <a href="https://github.com/ericmehl">Eric Mehl</a>, allowing Gaffer task networks to be dispatched and rendered on a Deadline managed render farm.</p>
+                <p class="lead"><a href="https://github.com/hypothetical-inc/GafferDeadline">GafferDeadline</a> is a <a href="https://awsthinkbox.com/deadline">Deadline</a> dispatcher created by <a href="https://github.com/ericmehl">Eric Mehl</a>, allowing Gaffer task networks to be dispatched and rendered on a Deadline managed render farm.</p>
                 <h3><i class="fas fa-cog"></i> ShotGrid Integration</h3>
                 <p class="lead"><a href="https://github.com/diegogarciahuerta/tk-gaffer">TK-Gaffer</a> is a <a href="https://shotgridsoftware.com/">ShotGrid</a> integration created by <a href="https://github.com/diegogarciahuerta">Diego Garcia Huerta</a>, with support for file management, asset loading, publishing, and more.</p>
             </div>


### PR DESCRIPTION
Updated download page to include links for the 1.4 GCC 9 and GCC 11 release packages, and a touch of overall spring cleaning in honour of the Gaffer 1.4.0.0 release...