### PR TITLE
Add link to release notes

### DIFF
--- a/download.html
+++ b/download.html
@@ -14,6 +14,7 @@ title: Gaffer | Download
             <a class="btn btn-block btn-lg btn-color-a" style="font-size: 16px" href="https://github.com/GafferHQ/gaffer/releases/download/{{ site.latestGafferVersion }}/gaffer-{{ site.latestGafferVersion }}-linux-gcc9.tar.gz"><i class="fa fa-download"></i>Gaffer for Linux (GCC 9)</a>
             <a class="btn btn-block btn-lg btn-color-a" style="font-size: 16px" href="https://github.com/GafferHQ/gaffer/releases/download/{{ site.latestGafferVersion }}/gaffer-{{ site.latestGafferVersion }}-linux-gcc11.tar.gz"><i class="fa fa-download"></i>Gaffer for Linux (GCC 11)</a>
             <a class="btn btn-block btn-lg btn-color-a" style="font-size: 16px" href="https://github.com/GafferHQ/gaffer/releases/download/{{ site.latestGafferVersion }}/gaffer-{{ site.latestGafferVersion }}-windows.zip"><i class="fa fa-download"></i>Gaffer for Windows</a>
+            <a class="btn btn-block btn-lg btn-color-line" style="font-size: 16px" href="https://www.gafferhq.org/documentation/{{ site.latestGafferVersion }}/ReleaseNotes/{{ site.latestGafferVersion }}.html"><i class="fa fa-sticky-note"></i>Release Notes</a>
         </div>
         <div class="col-sm-7">
             <ul style="padding-left: 1em; list-style-type:'➜'">


### PR DESCRIPTION
Quick attempt at sticking a link to the release notes below the download links.

![image](https://github.com/GafferHQ/gafferhq.github.io/assets/50844517/7eac1918-d0ce-4762-aff4-47cd7fd5ec45)
