### PR TITLE
CI : Update to Ruby 3.3

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,13 +10,13 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3.3
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       with:
         path: vendor/bundle
         key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,7 +14,7 @@ jobs:
 
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7
+        ruby-version: 3.3
 
     - uses: actions/cache@v2
       with:
@@ -27,8 +27,8 @@ jobs:
       run: |
         bundle config path vendor/bundle
         bundle install
-        gem install nokogiri -v "~>1.15.6"
-        gem install html-proofer -v "<5.0.0" --minimal-deps
+        gem install nokogiri
+        gem install html-proofer --minimal-deps
       env:
         NOKOGIRI_USE_SYSTEM_LIBRARIES: true # speeds up installation of html-proofer
 

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - uses: actions/setup-python@v2
       with:


### PR DESCRIPTION
GitHub Pages has been [updated](https://pages.github.com/versions/) to run Ruby 3.3, so we update to match. This allows us to unpin the `nokogiri` and `html-proofer` gem versions to fix the currently broken on Ruby 2.7 `html-proofer` checks. 

At the same time, we update the `checkout` and `cache` actions versions to modern Node20 supported actions.